### PR TITLE
Cleanup based on upstream code

### DIFF
--- a/src/qgeomapmaplibregl.cpp
+++ b/src/qgeomapmaplibregl.cpp
@@ -26,7 +26,6 @@
 #include <QtLocation/private/qgeoprojection_p.h>
 #include <QtQuick/QQuickWindow>
 #include <QtQuick/QSGImageNode>
-#include <QtQuick/private/qsgtexture_p.h>
 #include <QtQuick/private/qsgcontext_p.h> // for debugging the context name
 
 #include <QMapLibreGL/Types>
@@ -62,10 +61,10 @@ QSGNode *QGeoMapMapLibreGLPrivate::updateSceneGraph(QSGNode *node, QQuickWindow 
 
     if (m_viewportSize.isEmpty()) {
         delete node;
-        return 0;
+        return nullptr;
     }
 
-    QMapLibreGL::Map *map = 0;
+    QMapLibreGL::Map *map{};
     if (!node) {
         QOpenGLContext *currentCtx = QOpenGLContext::currentContext();
         if (!currentCtx) {
@@ -459,7 +458,7 @@ void QGeoMapMapLibreGL::onParameterPropertyUpdated(QGeoMapParameter *param, cons
     emit sgNodeChanged();
 }
 
-void QGeoMapMapLibreGL::copyrightsChanged(const QString &copyrightsHtml)
+void QGeoMapMapLibreGL::copyrightsChangedHandler(const QString &copyrightsHtml)
 {
     Q_D(QGeoMapMapLibreGL);
 
@@ -470,5 +469,5 @@ void QGeoMapMapLibreGL::copyrightsChanged(const QString &copyrightsHtml)
             + copyrightsHtmlFinal + "</th></tr></table>";
     }
 
-    QGeoMap::copyrightsChanged(copyrightsHtmlFinal);
+    emit QGeoMap::copyrightsChanged(copyrightsHtmlFinal);
 }

--- a/src/qgeomapmaplibregl.h
+++ b/src/qgeomapmaplibregl.h
@@ -44,7 +44,7 @@ private Q_SLOTS:
     void onParameterPropertyUpdated(QGeoMapParameter *param, const char *propertyName);
 
 public Q_SLOTS:
-    void copyrightsChanged(const QString &copyrightsHtml);
+    void copyrightsChangedHandler(const QString &copyrightsHtml);
 
 private:
     QSGNode *updateSceneGraph(QSGNode *oldNode, QQuickWindow *window) override;

--- a/src/qgeoserviceproviderpluginmaplibregl.cpp
+++ b/src/qgeoserviceproviderpluginmaplibregl.cpp
@@ -22,7 +22,7 @@ QGeoCodingManagerEngine *QGeoServiceProviderFactoryMapLibreGL::createGeocodingMa
     Q_UNUSED(error);
     Q_UNUSED(errorString);
 
-    return 0;
+    return nullptr;
 }
 
 QGeoMappingManagerEngine *QGeoServiceProviderFactoryMapLibreGL::createMappingManagerEngine(
@@ -38,7 +38,7 @@ QGeoRoutingManagerEngine *QGeoServiceProviderFactoryMapLibreGL::createRoutingMan
     Q_UNUSED(error);
     Q_UNUSED(errorString);
 
-    return 0;
+    return nullptr;
 }
 
 QPlaceManagerEngine *QGeoServiceProviderFactoryMapLibreGL::createPlaceManagerEngine(
@@ -48,7 +48,7 @@ QPlaceManagerEngine *QGeoServiceProviderFactoryMapLibreGL::createPlaceManagerEng
     Q_UNUSED(error);
     Q_UNUSED(errorString);
 
-    return 0;
+    return nullptr;
 }
 
 QT_END_NAMESPACE

--- a/src/qgeoserviceproviderpluginmaplibregl.h
+++ b/src/qgeoserviceproviderpluginmaplibregl.h
@@ -24,16 +24,16 @@ public:
 
     QGeoCodingManagerEngine *createGeocodingManagerEngine(const QVariantMap &parameters,
                                                           QGeoServiceProvider::Error *error,
-                                                          QString *errorString) const;
+                                                          QString *errorString) const override;
     QGeoMappingManagerEngine *createMappingManagerEngine(const QVariantMap &parameters,
                                                          QGeoServiceProvider::Error *error,
-                                                         QString *errorString) const;
+                                                         QString *errorString) const override;
     QGeoRoutingManagerEngine *createRoutingManagerEngine(const QVariantMap &parameters,
                                                          QGeoServiceProvider::Error *error,
-                                                         QString *errorString) const;
+                                                         QString *errorString) const override;
     QPlaceManagerEngine *createPlaceManagerEngine(const QVariantMap &parameters,
                                                   QGeoServiceProvider::Error *error,
-                                                  QString *errorString) const;
+                                                  QString *errorString) const override;
 };
 
 QT_END_NAMESPACE

--- a/src/qmaplibreglstylechange.cpp
+++ b/src/qmaplibreglstylechange.cpp
@@ -65,7 +65,7 @@ QMapLibreGL::Feature featureFromMapCircle(QDeclarativeCircleMapItem *mapItem)
     const QGeoProjectionWebMercator &p = static_cast<const QGeoProjectionWebMercator&>(mapItem->map()->geoProjection());
     QList<QGeoCoordinate> path;
     QGeoCoordinate leftBound;
-    QDeclarativeCircleMapItemPrivateCPU::calculatePeripheralPoints(path, mapItem->center(), mapItem->radius(), circleSamples, leftBound);
+    QDeclarativeCircleMapItemPrivate::calculatePeripheralPoints(path, mapItem->center(), mapItem->radius(), circleSamples, leftBound);
     QList<QDoubleVector2D> pathProjected;
     for (const QGeoCoordinate &c : qAsConst(path))
         pathProjected << p.geoToMapProjection(c);

--- a/src/qsgmaplibreglnode.cpp
+++ b/src/qsgmaplibreglnode.cpp
@@ -31,8 +31,7 @@ QSGMapLibreGLTextureNode::QSGMapLibreGLTextureNode(const QMapLibreGL::Settings &
     m_map.reset(new QMapLibreGL::Map(nullptr, settings, size.expandedTo(minTextureSize), pixelRatio));
 
     QObject::connect(m_map.get(), &QMapLibreGL::Map::needsRendering, geoMap, &QGeoMap::sgNodeChanged);
-    QObject::connect(m_map.get(), &QMapLibreGL::Map::copyrightsChanged, geoMap,
-            static_cast<void (QGeoMap::*)(const QString &)>(&QGeoMapMapLibreGL::copyrightsChanged));
+    QObject::connect(m_map.get(), &QMapLibreGL::Map::copyrightsChanged, geoMap, &QGeoMapMapLibreGL::copyrightsChangedHandler);
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -50,8 +49,6 @@ void QSGMapLibreGLTextureNode::resize(const QSize &size, qreal pixelRatio)
     m_map->setFramebufferObject(m_fbo->handle(), fbSize);
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    // There is no elegant way to set new frame buffer object to already created texture.
-    // So, a quick hack-solution is to re-create the texture as well, every time the size changes.
     setTexture(QNativeInterface::QSGOpenGLTexture::fromNative(m_fbo->texture(), window, fbSize, QQuickWindow::TextureHasAlphaChannel));
     setOwnsTexture(true);
 #else
@@ -123,8 +120,7 @@ QSGMapLibreGLRenderNode::QSGMapLibreGLRenderNode(const QMapLibreGL::Settings &se
 {
     m_map.reset(new QMapLibreGL::Map(nullptr, settings, size, pixelRatio));
     QObject::connect(m_map.get(), &QMapLibreGL::Map::needsRendering, geoMap, &QGeoMap::sgNodeChanged);
-    QObject::connect(m_map.get(), &QMapLibreGL::Map::copyrightsChanged, geoMap,
-            static_cast<void (QGeoMap::*)(const QString &)>(&QGeoMapMapLibreGL::copyrightsChanged));
+    QObject::connect(m_map.get(), &QMapLibreGL::Map::copyrightsChanged, geoMap, &QGeoMapMapLibreGL::copyrightsChangedHandler);
 }
 
 QMapLibreGL::Map* QSGMapLibreGLRenderNode::map() const


### PR DESCRIPTION
- properly handle `copyrightsChanged` signal
- remove unneeded casting
- prefer `nullptr` over 0
- declare overriden methods