### PR TITLE
Reset state before rendering MapLibre

### DIFF
--- a/src/qsgmaplibreglnode.cpp
+++ b/src/qsgmaplibreglnode.cpp
@@ -87,6 +87,10 @@ void QSGMapLibreGLTextureNode::render(QQuickWindow *window)
     GLint alignment;
     f->glGetIntegerv(GL_UNPACK_ALIGNMENT, &alignment);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QQuickOpenGLUtils::resetOpenGLState();
+#endif
+
     m_fbo->bind();
 
     f->glClearColor(0.f, 0.f, 0.f, 0.f);


### PR DESCRIPTION
Reset OpenGL state also before rendering MapLibre in Qt 6 to make sure there is no unwanted interference.